### PR TITLE
Use gsub

### DIFF
--- a/lib/arabic_normalizer.rb
+++ b/lib/arabic_normalizer.rb
@@ -28,24 +28,18 @@ module ArabicNormalizer
   SUKUN = "\u0652"
 
   def self.normalize(string)
-    s = string.split("")
-
-    s.map! do |elem|
-      case elem
-      when ALEF_MADDA, ALEF_HAMZA_ABOVE, ALEF_HAMZA_BELOW
-        ALEF
-      when YEH_HAMZA, DOTLESS_YEH
-        YEH
-      when TEH_MARBOUTA
-        HEH
-      when WAW_HAMZA
-        WAW
-      when TATWEEL, FATHATAN, DAMMATAN, KASRATAN, FATHA, DAMMA, KASRA, SHADDA, SUKUN
-        ""
-      else
-        elem
-      end
-    end
-    s.join("")
+    string.gsub(/[
+      #{ALEF_MADDA}#{ALEF_HAMZA_ABOVE}#{ALEF_HAMZA_BELOW}
+      #{YEH_HAMZA}#{DOTLESS_YEH}
+      #{TEH_MARBOUTA}
+      #{WAW_HAMZA}
+      #{TATWEEL}#{FATHATAN}#{DAMMATAN}#{KASRATAN}#{FATHA}#{DAMMA}#{KASRA}#{SHADDA}#{SUKUN}
+    ]/x,
+      ALEF_MADDA => ALEF, ALEF_HAMZA_ABOVE => ALEF, ALEF_HAMZA_BELOW => ALEF,
+      YEH_HAMZA => YEH, DOTLESS_YEH => YEH,
+      TEH_MARBOUTA => HEH,
+      WAW_HAMZA => WAW,
+      TATWEEL => '', FATHATAN => '', DAMMATAN => '', KASRATAN => '', FATHA => '', DAMMA => '', KASRA => '', SHADDA => '', SUKUN => ''
+    )
   end
 end

--- a/spec/arabic_normalizer_spec.rb
+++ b/spec/arabic_normalizer_spec.rb
@@ -7,81 +7,81 @@ describe ArabicNormalizer do
 
   it "Normalizer should replace ALEF_HAMZA_ABOVE by ALEF" do
     test = "أسبوع"
-    expect(ArabicNormalizer::normalize(test)).to eq "اسبوع"
+    expect(ArabicNormalizer.normalize(test)).to eq "اسبوع"
   end
 
   it "Normalizer should replace ALEF_HAMZA_BELOW by ALEF" do
     test = "إنسان"
-    expect(ArabicNormalizer::normalize(test)).to eq "انسان"
+    expect(ArabicNormalizer.normalize(test)).to eq "انسان"
   end
 
   it "Normalizer should replace ALEF_MADDA by ALEF" do
     test = "الآن"
-    expect(ArabicNormalizer::normalize(test)).to eq "الان"
+    expect(ArabicNormalizer.normalize(test)).to eq "الان"
   end
 
   it "Normalizer should replace WAW_HAMZA by WAW" do
     test = "مسؤول"
-    expect(ArabicNormalizer::normalize(test)).to eq "مسوول"
+    expect(ArabicNormalizer.normalize(test)).to eq "مسوول"
   end
 
   it "Normalizer should replace YEH_HAMZA by YEH" do
     test = "شيئ"
-    expect(ArabicNormalizer::normalize(test)).to eq "شيي"
+    expect(ArabicNormalizer.normalize(test)).to eq "شيي"
   end
 
   it "Normalizer should replace DOTLESS_YEH by YEH" do
     test = "صدى"
-    expect(ArabicNormalizer::normalize(test)).to eq "صدي"
+    expect(ArabicNormalizer.normalize(test)).to eq "صدي"
   end
 
   it "Normalizer should replace TEH_MARBOUTA by HEH" do
     test = "عودة"
-    expect(ArabicNormalizer::normalize(test)).to eq "عوده"
+    expect(ArabicNormalizer.normalize(test)).to eq "عوده"
   end
 
   it "Normalizer should remove TATWEEL" do
     test = "قــــــال"
-    expect(ArabicNormalizer::normalize(test)).to eq "قال"
+    expect(ArabicNormalizer.normalize(test)).to eq "قال"
   end
 
   it "Normalizer should remove FATHATAN" do
     test = "شهراً"
-    expect(ArabicNormalizer::normalize(test)).to eq "شهرا"
+    expect(ArabicNormalizer.normalize(test)).to eq "شهرا"
   end
 
   it "Normalizer should remove DAMMATAN" do
     test = "مكتبٌ"
-    expect(ArabicNormalizer::normalize(test)).to eq "مكتب"
+    expect(ArabicNormalizer.normalize(test)).to eq "مكتب"
   end
 
   it "Normalizer should remove KASRATAN" do
     test = "شهرٍ"
-    expect(ArabicNormalizer::normalize(test)).to eq "شهر"
+    expect(ArabicNormalizer.normalize(test)).to eq "شهر"
   end
 
   it "Normalizer should remove FATHA" do
     test = "ولدَ"
-    expect(ArabicNormalizer::normalize(test)).to eq "ولد"
+    expect(ArabicNormalizer.normalize(test)).to eq "ولد"
   end
 
   it "Normalizer should remove DAMMA" do
     test = "ولدُ"
-    expect(ArabicNormalizer::normalize(test)).to eq "ولد"
+    expect(ArabicNormalizer.normalize(test)).to eq "ولد"
   end
 
   it "Normalizer should remove KASRA" do
     test = "شمسِ"
-    expect(ArabicNormalizer::normalize(test)).to eq "شمس"
+    expect(ArabicNormalizer.normalize(test)).to eq "شمس"
   end
 
   it "Normalizer should remove SHADDA" do
     test = "فعّال"
-    expect(ArabicNormalizer::normalize(test)).to eq "فعال"
+    expect(ArabicNormalizer.normalize(test)).to eq "فعال"
   end
 
   it "Normalizer should remove SUKUN" do
     test = "كسْر"
-    expect(ArabicNormalizer::normalize(test)).to eq "كسر"
+    expect(ArabicNormalizer.normalize(test)).to eq "كسر"
   end
 end


### PR DESCRIPTION
In Ruby, we can substitute characters with `String#gsub` method.
By using `gsub` we can finish our task with only one method call. (before we had 3 steps of `split, map, join`).

@jeaneldebs please review
