### PR TITLE
Should not match with whitespaces

### DIFF
--- a/lib/arabic_normalizer.rb
+++ b/lib/arabic_normalizer.rb
@@ -27,19 +27,17 @@ module ArabicNormalizer
   SHADDA = "\u0651"
   SUKUN = "\u0652"
 
+  NORMALIZATION_RULES = {
+    ALEF_MADDA => ALEF, ALEF_HAMZA_ABOVE => ALEF, ALEF_HAMZA_BELOW => ALEF,
+    YEH_HAMZA => YEH, DOTLESS_YEH => YEH,
+    TEH_MARBOUTA => HEH,
+    WAW_HAMZA => WAW,
+    TATWEEL => '', FATHATAN => '', DAMMATAN => '', KASRATAN => '', FATHA => '', DAMMA => '', KASRA => '', SHADDA => '', SUKUN => ''
+  }
+
+  NORMALIZATION_REGEX = /[#{NORMALIZATION_RULES.keys.join}]/.freeze
+
   def self.normalize(string)
-    string.gsub(/[
-      #{ALEF_MADDA}#{ALEF_HAMZA_ABOVE}#{ALEF_HAMZA_BELOW}
-      #{YEH_HAMZA}#{DOTLESS_YEH}
-      #{TEH_MARBOUTA}
-      #{WAW_HAMZA}
-      #{TATWEEL}#{FATHATAN}#{DAMMATAN}#{KASRATAN}#{FATHA}#{DAMMA}#{KASRA}#{SHADDA}#{SUKUN}
-    ]/x,
-      ALEF_MADDA => ALEF, ALEF_HAMZA_ABOVE => ALEF, ALEF_HAMZA_BELOW => ALEF,
-      YEH_HAMZA => YEH, DOTLESS_YEH => YEH,
-      TEH_MARBOUTA => HEH,
-      WAW_HAMZA => WAW,
-      TATWEEL => '', FATHATAN => '', DAMMATAN => '', KASRATAN => '', FATHA => '', DAMMA => '', KASRA => '', SHADDA => '', SUKUN => ''
-    )
+    string.gsub(NORMALIZATION_REGEX, NORMALIZATION_RULES)
   end
 end

--- a/spec/arabic_normalizer_spec.rb
+++ b/spec/arabic_normalizer_spec.rb
@@ -84,4 +84,9 @@ describe ArabicNormalizer do
     test = "كسْر"
     expect(ArabicNormalizer.normalize(test)).to eq "كسر"
   end
+
+  it "should not remove whitespaces" do
+    test = "اطباق بالفرن"
+    expect(ArabicNormalizer::normalize(test)).to eq test
+  end
 end


### PR DESCRIPTION
The current definition of matching rule matches any whitespaces.
With this fix, we only match the character defined in `NORMALIZATION_RULES`.
